### PR TITLE
Add wrapped_scalar_tensor

### DIFF
--- a/src/wrappers/tensor.rs
+++ b/src/wrappers/tensor.rs
@@ -1,3 +1,4 @@
+use super::scalar::Scalar;
 use super::stream::ReadSeekAdapter;
 use super::utils::{path_to_cstring, ptr_to_string};
 use super::{
@@ -500,6 +501,23 @@ impl Tensor {
         device: Device,
     ) -> Tensor {
         Self::f_from_blob(data, size, strides, kind, device).unwrap()
+    }
+
+    /// Creates a wrapped scalar tensor.
+    /// Returned tensor's `is_wrapped_number_` flag is set to true.
+    pub fn f_wrapped_scalar_tensor<S: Into<Scalar>>(
+        s: S,
+        device: Device,
+    ) -> Result<Tensor, TchError> {
+        let c_tensor =
+            unsafe_torch_err!(at_wrapped_scalar_tensor(s.into().c_scalar, device.c_int()));
+        Ok(Tensor { c_tensor })
+    }
+
+    /// Creates a wrapped scalar tensor.
+    /// Returned tensor's `is_wrapped_number_` flag is set to true.
+    pub fn wrapped_scalar_tensor<S: Into<Scalar>>(s: S, device: Device) -> Tensor {
+        Self::f_wrapped_scalar_tensor(s, device).unwrap()
     }
 
     /// Converts some byte data to a tensor with some specified kind and shape.

--- a/torch-sys/libtch/torch_api.cpp
+++ b/torch-sys/libtch/torch_api.cpp
@@ -7,6 +7,7 @@
 #include<torch/csrc/jit/runtime/graph_executor.h>
 #include<torch/torch.h>
 #include<ATen/autocast_mode.h>
+#include<ATen/ScalarOps.h>
 #include<torch/script.h>
 #include<torch/csrc/jit/passes/tensorexpr_fuser.h>
 #include<torch/csrc/jit/codegen/cuda/interface.h>
@@ -84,6 +85,14 @@ tensor at_tensor_of_data(void *vs, int64_t *dims, size_t ndims, size_t element_s
     void *tensor_data = tensor.data_ptr();
     memcpy(tensor_data, vs, tensor.numel() * element_size_in_bytes);
     return new torch::Tensor(tensor);
+  )
+  return nullptr;
+}
+
+tensor at_wrapped_scalar_tensor(scalar s, int device) {
+  PROTECT(
+    auto outputs__ = at::native::wrapped_scalar_tensor(*s, device_of_int(device));
+    return new torch::Tensor(outputs__);
   )
   return nullptr;
 }

--- a/torch-sys/libtch/torch_api.h
+++ b/torch-sys/libtch/torch_api.h
@@ -33,6 +33,7 @@ void at_manual_seed(int64_t);
 tensor at_new_tensor();
 tensor at_tensor_of_blob(void *data, int64_t *dims, size_t ndims, int64_t *strides, size_t nstrides, int type, int device);
 tensor at_tensor_of_data(void *vs, int64_t *dims, size_t ndims, size_t element_size_in_bytes, int type);
+tensor at_wrapped_scalar_tensor(scalar s, int device);
 void at_copy_data(tensor tensor, void *vs, size_t numel, size_t element_size_in_bytes);
 tensor at_shallow_clone(tensor);
 

--- a/torch-sys/src/lib.rs
+++ b/torch-sys/src/lib.rs
@@ -94,6 +94,7 @@ extern "C" {
         kind: c_int,
         device: c_int,
     ) -> *mut C_tensor;
+    pub fn at_wrapped_scalar_tensor(s: *mut C_scalar, device: c_int) -> *mut C_tensor;
     pub fn at_grad_set_enabled(b: c_int) -> c_int;
     pub fn at_save(arg: *mut C_tensor, filename: *const c_char);
     pub fn at_save_to_stream(arg: *mut C_tensor, stream_ptr: *mut c_void);


### PR DESCRIPTION
Add `wrapped_scalar_tensor` which creates a tensor with `is_wrapped_number_` field set.
This is required to pass tensor arguments which is actually scalar value. In this case, the wrapped number's dtype would be changed by other operand's dtype while op is evaluated.

Next example demonstrates this case. The returned tensor `c` is `torch.int8` type although `b` does not fit in `torch.int8`.
```
>>> import torch
>>> a = torch.tensor(1, dtype=torch.int8)
>>> b = 6000
>>> c = a - b
>>> print(c)
tensor(-111, dtype=torch.int8)
```
We can do the same thing in rust by creating a tensor with `wrapped_scalar_tensor()`
```
let a = Tensor::scalar_tensor(1, (Kind::Int8, Device::Cpu));
let b = Tensor::wrapped_scalar_tensor(6000);
let c = a.sub_tensor(&b);
assert!(c.kind() == Kind::Int8)
```
