### PR TITLE
Remove libgomp dependency from torch-sys.

### DIFF
--- a/torch-sys/build.rs
+++ b/torch-sys/build.rs
@@ -501,12 +501,6 @@ fn main() -> anyhow::Result<()> {
         if use_hip {
             system_info.link("c10_hip");
         }
-
-        let target = env::var("TARGET").context("TARGET variable not set")?;
-
-        if !target.contains("msvc") && !target.contains("apple") {
-            println!("cargo:rustc-link-lib=gomp");
-        }
     }
     Ok(())
 }


### PR DESCRIPTION
(This PR is meant to be sent to the upstream in the future, so all numbers refer to issue numbers in the original repository. The correct link wasn't used in order to avoid unnecessary mentions.)

This workaround originates from 99. This was meant to solve 95, which was ultimately found to be caused by an incorrect shared library name. In fact the current name of "tch-rs" is a result of the subsequent renaming proposed by 97, but the original PR was ultimately closed in favor of the upstream fix instead.

As noted in 355, libtorch never actually depends on the system libgomp because it bundles its own version with an already mangled SONAME. There is a symlink to the unmangled name as well, but that seems only a compatibility measure for other libraries. Torch-sys doesn't require any other library, so `-lgomp` can be safely removed.