### PR TITLE
Minimize additional features for the `zip` dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,11 @@ num-traits = "0.2.15"
 rand = "0.8"
 thiserror = "1"
 torch-sys = { version = "0.14.0", path = "torch-sys" }
-zip = "0.6"
+zip = { version = "0.6", default-features = false, features = [
+    # Any other features, in particular `deflate-<backend>` features
+    # may be added by other crates and override the default backend.
+    "deflate",
+] }
 half = "2"
 safetensors = "0.3.0"
 

--- a/torch-sys/Cargo.toml
+++ b/torch-sys/Cargo.toml
@@ -21,7 +21,7 @@ cc = "1.0.61"
 ureq = { version = "2.6", optional = true, features = ["json"] }
 serde_json = { version = "1.0", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
-zip = "0.6"
+zip = { version = "0.6", default-features = false, features = ["deflate"] }
 
 [features]
 download-libtorch = ["ureq", "serde", "serde_json"]

--- a/torch-sys/Cargo.toml
+++ b/torch-sys/Cargo.toml
@@ -21,10 +21,10 @@ cc = "1.0.61"
 ureq = { version = "2.6", optional = true, features = ["json"] }
 serde_json = { version = "1.0", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
-zip = { version = "0.6", default-features = false, features = ["deflate"] }
+zip = { version = "0.6", optional = true, default-features = false, features = ["deflate"] }
 
 [features]
-download-libtorch = ["ureq", "serde", "serde_json"]
+download-libtorch = ["ureq", "serde", "serde_json", "zip"]
 doc-only = []
 python-extension = []
 


### PR DESCRIPTION
Zip 0.6 and later adds a lot of transitive dependencies to handle the full ZIP specification, which is rarely used in practice to be say the least. (Have you ever seen a ZIP file using Zstandard in the wild?)

For tch, zip is used to read and write `.npz` archive files which use Python's ZipFile and doesn't need any fancy feature: we can safely assume that every file uses compression methods 0 (stored) or 8 (deflate), and encryption is never used. Only actual variations are flate2's deflate backends, but any non-default backends do override the default backend of minix-oxide so we don't necessarily forbid the use of other backends as is.

For torch-sys, zip is used to extract downloaded libtorch archives, which might be huge (up to 3 GB) but also don't need any fancy feature. Alternative backends can still be faster to decompress them, but this cost is one-off and miniz is not extremelly slower than others anyway.

This PR also addresses an issue that the `zip` build-dependency is required even when `download-libtorch` feature is not used, as in the default feature set.