### PR TITLE
Support AArch64

### DIFF
--- a/torch-sys/build.rs
+++ b/torch-sys/build.rs
@@ -376,6 +376,9 @@ impl SystemInfo {
                 // https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key
                 println!("cargo:libtorch_lib={}", self.libtorch_lib_dir.display());
 
+                // NOTE: Compiling torch-sys on AArch64 shows depceration warnings for
+                // at::autocast::is_enabled(). -Wno-deprecated-declarations is added to supress
+                // this warning.
                 let mut build = cc::Build::new();
                 build
                     .cpp(true)
@@ -384,6 +387,7 @@ impl SystemInfo {
                     .includes(&self.libtorch_include_dirs)
                     .flag(format!("-Wl,-rpath={}", self.libtorch_lib_dir.display()))
                     .flag("-std=c++17")
+                    .flag("-Wno-deprecated-declarations")
                     .flag(format!("-D_GLIBCXX_USE_CXX11_ABI={}", self.cxx11_abi))
                     .flag("-DGLOG_USE_GLOG_EXPORT")
                     .files(&c_files);
@@ -499,21 +503,27 @@ fn main() -> anyhow::Result<()> {
         if cfg!(feature = "python-extension") {
             system_info.link("torch_python")
         }
-        if system_info.link_type == LinkType::Static {
-            system_info.link("clog");
-            system_info.link("cpuinfo");
-            system_info.link("eigen_blas");
-            system_info.link("fmt");
-            system_info.link("pthreadpool");
-            system_info.link("pytorch_qnnpack");
-            system_info.link("XNNPACK");
-            system_info.link("microkernels-prod");
-        }
+
+        // NOTE: Link order is modified to support AArch64 due to default linker differences.
+        // Unlike rust-lld, which is the default linker for x86_64, AArch64's default linker
+        // cannot resolve cicrular dependencies. Therefore, the linked libraries must be sorted
+        // in a topological order for proper linkage.
         system_info.link("torch_cpu");
         system_info.link("torch");
         system_info.link("c10");
         if use_hip {
             system_info.link("c10_hip");
+        }
+
+        if system_info.link_type == LinkType::Static {
+            system_info.link("pytorch_qnnpack");
+            system_info.link("XNNPACK");
+            system_info.link("microkernels-prod");
+            system_info.link("eigen_blas");
+            system_info.link("fmt");
+            system_info.link("pthreadpool");
+            system_info.link("cpuinfo");
+            system_info.link("clog");
         }
     }
     Ok(())


### PR DESCRIPTION
이 PR은 https://github.com/furiosa-ai/tch-rs/pull/19 merge 이후 merge되어야 합니다.

### Problem
* AArch64에서`furiosa-runtime`의 `furiosa-generator`에서 unit test를 돌리면 다음과 같은 에러가 발생합니다. ([error.log](https://github.com/user-attachments/files/26295982/error.log))
* 이는 AArch64와 x86 Rust에서 사용하는 [linker의 차이](https://blog.rust-lang.org/2025/09/01/rust-lld-on-1.90.0-stable/)로 발생하는 문제입니다. (`gnu-cc` VS `gnu-lld-cc`)

<details>

<summary>AArch64</summary>

```
root@aarch64-jammy:~/furiosa-runtime/furiosa-generator# rustc --print target-spec-json -Z unstable-options
{
  "arch": "aarch64",
  "crt-objects-fallback": "false",
  "crt-static-respected": true,
  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32",
  "default-uwtable": true,
  "dynamic-linking": true,
  "env": "gnu",
  "features": "+v8a,+outline-atomics",
  "frame-pointer": "non-leaf",
  "has-rpath": true,
  "has-thread-local": true,
  "linker-flavor": "gnu-cc",
  "llvm-target": "aarch64-unknown-linux-gnu",
  "max-atomic-width": 128,
  "metadata": {
    "description": "ARM64 Linux (kernel 4.1, glibc 2.17+)",
    "host_tools": true,
    "std": true,
    "tier": 1
  },
  "os": "linux",
  "position-independent-executables": true,
  "relro-level": "full",
  "stack-probes": {
    "kind": "inline"
  },
  "supported-sanitizers": [
    "address",
    "leak",
    "memory",
    "thread",
    "hwaddress",
    "cfi",
    "memtag",
    "kcfi",
    "realtime"
  ],
  "supported-split-debuginfo": [
    "packed",
    "unpacked",
    "off"
  ],
  "supports-xray": true,
  "target-family": [
    "unix"
  ],
  "target-mcount": "\u0001_mcount",
  "target-pointer-width": 64
}
```

</details>

<details>

<summary>x86_64</summary>

```
❯ rustc --print target-spec-json -Z unstable-options
{
  "arch": "x86_64",
  "cpu": "x86-64",
  "crt-static-respected": true,
  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
  "default-uwtable": true,
  "dynamic-linking": true,
  "env": "gnu",
  "has-rpath": true,
  "has-thread-local": true,
  "link-self-contained": {
    "components": [
      "linker"
    ]
  },
  "linker-flavor": "gnu-lld-cc",
  "llvm-target": "x86_64-unknown-linux-gnu",
  "max-atomic-width": 64,
  "metadata": {
    "description": "64-bit Linux (kernel 3.2+, glibc 2.17+)",
    "host_tools": true,
    "std": true,
    "tier": 1
  },
  "os": "linux",
  "plt-by-default": false,
  "position-independent-executables": true,
  "pre-link-args": {
    "gnu-cc": [
      "-m64"
    ],
    "gnu-lld-cc": [
      "-m64"
    ]
  },
  "relro-level": "full",
  "stack-probes": {
    "kind": "inline"
  },
  "static-position-independent-executables": true,
  "supported-sanitizers": [
    "address",
    "leak",
    "memory",
    "thread",
    "cfi",
    "kcfi",
    "safestack",
    "dataflow",
    "realtime"
  ],
  "supported-split-debuginfo": [
    "packed",
    "unpacked",
    "off"
  ],
  "supports-xray": true,
  "target-family": [
    "unix"
  ],
  "target-pointer-width": 64
}
```

</details>

* `gnu-cc`는 `gnu-lld-cc`와 달리 Circular dependency를 resolve하지 못합니다. 따라서 library link 순서에 topological sort가 적용되어야 합니다. 


### Solution
* `torch-sys` 에서 static library link order는 topological sort해 정리합니다.

### Testing
<!-- Specify execution time for newly added unit tests -->
* npu-tools의 CI 통과를 확인했습니다.